### PR TITLE
Added an option to gprofiler CLI to use perfspect HW metrics collection and provide the path to it

### DIFF
--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -181,8 +181,7 @@ class GProfiler:
         self._usage_logger = usage_logger
         if self._collect_metrics:
             self._system_metrics_monitor: SystemMetricsMonitorBase = SystemMetricsMonitor(
-                stop_event = self._profiler_state.stop_event,
-                perfspect_path = perfspect_path
+                stop_event=self._profiler_state.stop_event, perfspect_path=perfspect_path
             )
         else:
             self._system_metrics_monitor = NoopSystemMetricsMonitor()

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -57,7 +57,7 @@ from gprofiler.metadata.enrichment import EnrichmentOptions
 from gprofiler.metadata.external_metadata import ExternalMetadataStaleError, read_external_metadata
 from gprofiler.metadata.metadata_collector import get_current_metadata, get_static_metadata
 from gprofiler.metadata.system_metadata import get_hostname, get_run_mode, get_static_system_info
-from gprofiler.platform import is_linux, is_windows, is_aarch64
+from gprofiler.platform import is_aarch64, is_linux, is_windows
 from gprofiler.profiler_state import ProfilerState
 from gprofiler.profilers.factory import get_profilers
 from gprofiler.profilers.profiler_base import NoopProfiler, ProcessProfilerBase, ProfilerInterface

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -57,7 +57,7 @@ from gprofiler.metadata.enrichment import EnrichmentOptions
 from gprofiler.metadata.external_metadata import ExternalMetadataStaleError, read_external_metadata
 from gprofiler.metadata.metadata_collector import get_current_metadata, get_static_metadata
 from gprofiler.metadata.system_metadata import get_hostname, get_run_mode, get_static_system_info
-from gprofiler.platform import is_linux, is_windows
+from gprofiler.platform import is_linux, is_windows, is_aarch64
 from gprofiler.profiler_state import ProfilerState
 from gprofiler.profilers.factory import get_profilers
 from gprofiler.profilers.profiler_base import NoopProfiler, ProcessProfilerBase, ProfilerInterface
@@ -137,6 +137,7 @@ class GProfiler:
         controller_process: Optional[Process] = None,
         external_metadata_path: Optional[Path] = None,
         heartbeat_file_path: Optional[Path] = None,
+        perfspect_path: Optional[Path] = None,
     ):
         self._output_dir = output_dir
         self._flamegraph = flamegraph
@@ -157,6 +158,7 @@ class GProfiler:
         self._duration = duration
         self._external_metadata_path = external_metadata_path
         self._heartbeat_file_path = heartbeat_file_path
+        self._perfspect_path = perfspect_path
         if self._collect_metadata:
             self._static_metadata = get_static_metadata(self._spawn_time, user_args, self._external_metadata_path)
         self._executor = concurrent.futures.ThreadPoolExecutor(max_workers=10)
@@ -179,7 +181,8 @@ class GProfiler:
         self._usage_logger = usage_logger
         if self._collect_metrics:
             self._system_metrics_monitor: SystemMetricsMonitorBase = SystemMetricsMonitor(
-                self._profiler_state.stop_event
+                stop_event = self._profiler_state.stop_event,
+                perfspect_path = perfspect_path
             )
         else:
             self._system_metrics_monitor = NoopSystemMetricsMonitor()
@@ -834,6 +837,17 @@ def parse_cmd_args() -> configargparse.Namespace:
         "The file modification indicates the last snapshot time.",
     )
 
+    if is_linux() and not is_aarch64():
+        hw_metrics_options = parser.add_argument_group("hardware metrics")
+        hw_metrics_options.add_argument(
+            "--perfspect-path",
+            type=str,
+            dest="intel_perfspect_path",
+            default=None,
+            help="Enable HW metrics collection with Intel PerfSpect."
+            " Provide path to PerfSpect binary to enable collection.",
+        )
+
     args = parser.parse_args()
 
     args.perf_inject = args.nodejs_mode == "perf"
@@ -1103,6 +1117,13 @@ def main() -> None:
         if args.heartbeat_file is not None:
             heartbeat_file_path = Path(args.heartbeat_file)
 
+        perfspect_path: Optional[Path] = None
+        if args.intel_perfspect_path is not None:
+            perfspect_path = Path(args.intel_perfspect_path)
+            if not perfspect_path.is_file():
+                logger.error(f"Perfspect binary file {args.perfspect_path} does not exist!")
+                sys.exit(1)
+
         try:
             log_system_info()
         except Exception:
@@ -1187,6 +1208,7 @@ def main() -> None:
             processes_to_profile=processes_to_profile,
             external_metadata_path=external_metadata_path,
             heartbeat_file_path=heartbeat_file_path,
+            perfspect_path=perfspect_path,
         )
         logger.info("gProfiler initialized and ready to start profiling")
         if args.continuous:

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -181,7 +181,8 @@ class GProfiler:
         self._usage_logger = usage_logger
         if self._collect_metrics:
             self._system_metrics_monitor: SystemMetricsMonitorBase = SystemMetricsMonitor(
-                stop_event=self._profiler_state.stop_event, perfspect_path=perfspect_path
+                stop_event=self._profiler_state.stop_event,
+                perfspect_path=str(perfspect_path) if perfspect_path else None,
             )
         else:
             self._system_metrics_monitor = NoopSystemMetricsMonitor()

--- a/gprofiler/platform.py
+++ b/gprofiler/platform.py
@@ -30,6 +30,7 @@ def is_windows() -> bool:
 def is_linux() -> bool:
     return sys.platform == LINUX_PLATFORM_NAME
 
+
 @lru_cache(maxsize=None)
 def is_aarch64() -> bool:
     return platform.machine() == "aarch64"

--- a/gprofiler/platform.py
+++ b/gprofiler/platform.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import platform
 import sys
 from functools import lru_cache
 
@@ -28,3 +29,7 @@ def is_windows() -> bool:
 @lru_cache(maxsize=None)
 def is_linux() -> bool:
     return sys.platform == LINUX_PLATFORM_NAME
+
+@lru_cache(maxsize=None)
+def is_aarch64() -> bool:
+    return platform.machine() == "aarch64"

--- a/gprofiler/system_metrics.py
+++ b/gprofiler/system_metrics.py
@@ -1,4 +1,3 @@
-import os
 import statistics
 import subprocess
 from abc import ABCMeta, abstractmethod

--- a/gprofiler/system_metrics.py
+++ b/gprofiler/system_metrics.py
@@ -4,7 +4,7 @@ import subprocess
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
 from threading import Event, RLock, Thread
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 import psutil
 
@@ -32,6 +32,7 @@ class Metrics:
     cpu_tma_bad_spec: Optional[float] = None
     # The CPU TMA retiring between gProfiler cycles
     cpu_tma_retiring: Optional[float] = None
+
 
 class SystemMetricsMonitorBase(metaclass=ABCMeta):
     @abstractmethod
@@ -63,7 +64,16 @@ class SystemMetricsMonitorBase(metaclass=ABCMeta):
     def get_metrics(self) -> Metrics:
         hw_metrics = self._get_hw_metrics()
         if hw_metrics and len(hw_metrics) == 6:
-            return Metrics(self._get_cpu_utilization(), self._get_average_memory_utilization(), hw_metrics[0], hw_metrics[1], hw_metrics[2], hw_metrics[3], hw_metrics[4], hw_metrics[5])
+            return Metrics(
+                self._get_cpu_utilization(),
+                self._get_average_memory_utilization(),
+                hw_metrics[0],
+                hw_metrics[1],
+                hw_metrics[2],
+                hw_metrics[3],
+                hw_metrics[4],
+                hw_metrics[5],
+            )
         else:
             return Metrics(self._get_cpu_utilization(), self._get_average_memory_utilization())
 
@@ -73,7 +83,7 @@ class SystemMetricsMonitor(SystemMetricsMonitorBase):
         self,
         stop_event: Event,
         polling_rate_seconds: int = DEFAULT_POLLING_INTERVAL_SECONDS,
-        perfspect_path: str = None
+        perfspect_path: str = None,
     ):
         self._polling_rate_seconds = polling_rate_seconds
         self._mem_percentages: List[float] = []
@@ -81,8 +91,15 @@ class SystemMetricsMonitor(SystemMetricsMonitorBase):
         self._thread: Optional[Thread] = None
         self._lock = RLock()
         self._perfspect_thread: Optional[Thread] = None
-        self._hw_metrics = {'cpu_freq':[], 'cpu_cpi':[], 'cpu_tma_fe_bound':[], 'cpu_tma_be_bound':[], 'cpu_tma_bad_spec':[], 'cpu_tma_retiring':[]}
-        self._ps_process = None
+        self._hw_metrics: Dict[str, List[float]] = {
+            "cpu_freq": [],
+            "cpu_cpi": [],
+            "cpu_tma_fe_bound": [],
+            "cpu_tma_be_bound": [],
+            "cpu_tma_bad_spec": [],
+            "cpu_tma_retiring": [],
+        }
+        self._ps_process: Optional[subprocess.Popen[bytes]] = None
         self._perfspect_path = perfspect_path
 
         self._get_cpu_utilization()  # Call this once to set the necessary data
@@ -95,17 +112,32 @@ class SystemMetricsMonitor(SystemMetricsMonitorBase):
 
         if self._perfspect_path:
             assert self._perfspect_thread is None, "Perfspect is already running"
-            ps_cmd = [self._perfspect_path, 'metrics', '--metrics', '"CPU operating frequency (in GHz)","CPI","TMA_Frontend_Bound(%)","TMA_Bad_Speculation(%)","TMA_Backend_Bound(%)","TMA_Retiring(%)"', '--duration', '0', '--live', '--format', 'csv', '--interval', '10']
+            ps_cmd = [
+                self._perfspect_path,
+                "metrics",
+                "--metrics",
+                '"CPU operating frequency (in GHz)","CPI","TMA_Frontend_Bound(%)","TMA_Bad_Speculation(%)",'
+                '"TMA_Backend_Bound(%)","TMA_Retiring(%)"',
+                "--duration",
+                "0",
+                "--live",
+                "--format",
+                "csv",
+                "--interval",
+                "10",
+            ]
             self._ps_process = subprocess.Popen(ps_cmd, stdout=subprocess.PIPE)
-        #    ps_stdout, ps_stderr = ps_process.communicate()
-        #    try:
-        #        # wait 2 seconds to ensure it starts
-        #        ps_process.wait(2)
-        #    except subprocess.TimeoutExpired:
-        #        pass
-        #    else:
-        #        raise Exception(f"Command {ps_cmd} exited unexpectedly with {ps_process.returncode}")
-            self._perfspect_thread = Thread(target=self._continuously_poll_perfspect, args=(self._polling_rate_seconds,))
+            #    ps_stdout, ps_stderr = ps_process.communicate()
+            #    try:
+            #        # wait 2 seconds to ensure it starts
+            #        ps_process.wait(2)
+            #    except subprocess.TimeoutExpired:
+            #        pass
+            #    else:
+            #        raise Exception(f"Command {ps_cmd} exited unexpectedly with {ps_process.returncode}")
+            self._perfspect_thread = Thread(
+                target=self._continuously_poll_perfspect, args=(self._polling_rate_seconds,)
+            )
             self._perfspect_thread.start()
 
     def stop(self) -> None:
@@ -116,12 +148,14 @@ class SystemMetricsMonitor(SystemMetricsMonitorBase):
             raise ThreadStopTimeoutError("Timed out while waiting for the SystemMetricsMonitor internal thread to stop")
         self._thread = None
 
-        if self._perfspect_path:
+        if self._perfspect_path and self._ps_process:
             self._ps_process.kill()
             assert self._perfspect_thread is not None, "Perfspect is not running"
             self._perfspect_thread.join(STOP_TIMEOUT_SECONDS)
             if self._perfspect_thread.is_alive():
-                raise ThreadStopTimeoutError("Timed out while waiting for the SystemMetricsMonitor Perfspect thread to stop")
+                raise ThreadStopTimeoutError(
+                    "Timed out while waiting for the SystemMetricsMonitor Perfspect thread to stop"
+                )
             self._perfspect_thread = None
 
     def _continuously_poll_memory(self, polling_rate_seconds: int) -> None:
@@ -133,18 +167,20 @@ class SystemMetricsMonitor(SystemMetricsMonitorBase):
 
     def _continuously_poll_perfspect(self, polling_rate_seconds: int) -> None:
         while not self._stop_event.is_set():
-            metrics_str = self._ps_process.stdout.readline().decode()
+            metrics_str = (
+                self._ps_process.stdout.readline().decode() if self._ps_process and self._ps_process.stdout else ""
+            )
             print(metrics_str)
-            if metrics_str.startswith('TS,SKT,CPU,CID'):
+            if metrics_str.startswith("TS,SKT,CPU,CID"):
                 continue
-            metric_values = metrics_str.split(',')
-            if len(metric_values) > 0 and metric_values[0] != '':
-                self._hw_metrics['cpu_freq'].append(float(metric_values[4]))
-                self._hw_metrics['cpu_cpi'].append(float(metric_values[5]))
-                self._hw_metrics['cpu_tma_fe_bound'].append(float(metric_values[6]))
-                self._hw_metrics['cpu_tma_bad_spec'].append(float(metric_values[7]))
-                self._hw_metrics['cpu_tma_be_bound'].append(float(metric_values[8]))
-                self._hw_metrics['cpu_tma_retiring'].append(float(metric_values[9]))
+            metric_values = metrics_str.split(",")
+            if len(metric_values) > 0 and metric_values[0] != "":
+                self._hw_metrics["cpu_freq"].append(float(metric_values[4]))
+                self._hw_metrics["cpu_cpi"].append(float(metric_values[5]))
+                self._hw_metrics["cpu_tma_fe_bound"].append(float(metric_values[6]))
+                self._hw_metrics["cpu_tma_bad_spec"].append(float(metric_values[7]))
+                self._hw_metrics["cpu_tma_be_bound"].append(float(metric_values[8]))
+                self._hw_metrics["cpu_tma_retiring"].append(float(metric_values[9]))
             self._stop_event.wait(timeout=polling_rate_seconds)
 
     def _get_average_memory_utilization(self) -> Optional[float]:
@@ -160,29 +196,27 @@ class SystemMetricsMonitor(SystemMetricsMonitorBase):
             return average_memory
 
     def _get_cpu_utilization(self) -> float:
-        # None-blocking call. Must be called at least once before attempting to get a meaningful value.
-        # See `psutil.cpu_percent` documentation.
-        return psutil.cpu_percent(interval=None)
+        return psutil.cpu_percent(interval=None)  # type: ignore
 
     def _get_hw_metrics(self) -> List[float]:
-        current_length = len(self._hw_metrics['cpu_freq'])
+        current_length = len(self._hw_metrics["cpu_freq"])
         if current_length == 0:
-            return None
+            return []
 
         metric_list = []
-        metric_list.append(statistics.mean(self._hw_metrics['cpu_freq'][:current_length]))
-        metric_list.append(statistics.mean(self._hw_metrics['cpu_cpi'][:current_length]))
-        metric_list.append(statistics.mean(self._hw_metrics['cpu_tma_fe_bound'][:current_length]))
-        metric_list.append(statistics.mean(self._hw_metrics['cpu_tma_be_bound'][:current_length]))
-        metric_list.append(statistics.mean(self._hw_metrics['cpu_tma_bad_spec'][:current_length]))
-        metric_list.append(statistics.mean(self._hw_metrics['cpu_tma_retiring'][:current_length]))
+        metric_list.append(statistics.mean(self._hw_metrics["cpu_freq"][:current_length]))
+        metric_list.append(statistics.mean(self._hw_metrics["cpu_cpi"][:current_length]))
+        metric_list.append(statistics.mean(self._hw_metrics["cpu_tma_fe_bound"][:current_length]))
+        metric_list.append(statistics.mean(self._hw_metrics["cpu_tma_be_bound"][:current_length]))
+        metric_list.append(statistics.mean(self._hw_metrics["cpu_tma_bad_spec"][:current_length]))
+        metric_list.append(statistics.mean(self._hw_metrics["cpu_tma_retiring"][:current_length]))
 
-        self._hw_metrics['cpu_freq'] = []
-        self._hw_metrics['cpu_cpi'] = []
-        self._hw_metrics['cpu_tma_fe_bound'] = []
-        self._hw_metrics['cpu_tma_be_bound'] = []
-        self._hw_metrics['cpu_tma_bad_spec'] = []
-        self._hw_metrics['cpu_tma_retiring'] = []
+        self._hw_metrics["cpu_freq"] = []
+        self._hw_metrics["cpu_cpi"] = []
+        self._hw_metrics["cpu_tma_fe_bound"] = []
+        self._hw_metrics["cpu_tma_be_bound"] = []
+        self._hw_metrics["cpu_tma_bad_spec"] = []
+        self._hw_metrics["cpu_tma_retiring"] = []
 
         return metric_list
 

--- a/gprofiler/system_metrics.py
+++ b/gprofiler/system_metrics.py
@@ -195,8 +195,7 @@ class SystemMetricsMonitor(SystemMetricsMonitorBase):
             return average_memory
 
     def _get_cpu_utilization(self) -> float:
-        return psutil.cpu_percent(interval=None)  # type: ignore # virtual_memory doesn't have a
-        # return type is types-psutil
+        return psutil.cpu_percent(interval=None)
 
     def _get_hw_metrics(self) -> List[float]:
         current_length = len(self._hw_metrics["cpu_freq"])

--- a/gprofiler/system_metrics.py
+++ b/gprofiler/system_metrics.py
@@ -195,7 +195,8 @@ class SystemMetricsMonitor(SystemMetricsMonitorBase):
             return average_memory
 
     def _get_cpu_utilization(self) -> float:
-        return psutil.cpu_percent(interval=None)  # type: ignore
+        return psutil.cpu_percent(interval=None)  # type: ignore # virtual_memory doesn't have a
+        # return type is types-psutil
 
     def _get_hw_metrics(self) -> List[float]:
         current_length = len(self._hw_metrics["cpu_freq"])

--- a/gprofiler/system_metrics.py
+++ b/gprofiler/system_metrics.py
@@ -1,11 +1,11 @@
+import os
 import statistics
+import subprocess
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
 from threading import Event, RLock, Thread
 from typing import List, Optional
 
-import os
-import subprocess
 import psutil
 
 from gprofiler.exceptions import ThreadStopTimeoutError


### PR DESCRIPTION
Added an option to gprofiler CLI to use perfspect HW metrics collection and provide the path to it

## Description
(1) Added option "--perfspect-path" to gprofiler CLI.
Without path collection of HW metrics will not start.
(2) Disabled this option not on linux and on aarch64
(3) Fixed Python linter issues

## Related Issue
<!--- If there's an issue related, please link it here -->
<!--- If suggesting a new feature or a medium/big change, please discuss it in an issue first. -->
<!--- For small changes, it's okay to open a PR immediately. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? What does it improve? -->

## How Has This Been Tested?
Tested locally with and without option provided:
> sudo ./build/x86_64/gprofiler --perfspect-path ~/.../perfspect/perfspect -o ~/.../gprofiler_results/

Checked .col files after collection:
metrics field in file header with option -
` "metrics": {"cpu_avg": 0.1, "mem_avg": 2.9153846153846152, "cpu_freq": 1.102548528, "cpu_cpi": 2.3034023, "cpu_tma_fe_bound": 40.3853196, "cpu_tma_be_bound": 44.372709, "cpu_tma_bad_spec": 5.5948107, "cpu_tma_retiring": 9.64716058},`
without option -
`"metrics": {"cpu_avg": 0.1, "mem_avg": 2.823076923076923, "cpu_freq": null, "cpu_cpi": null, "cpu_tma_fe_bound": null, "cpu_tma_be_bound": null, "cpu_tma_bad_spec": null, "cpu_tma_retiring": null},`

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your changes are tested by the CI, you can just write that.-->

## Screenshots
<!--- (if appropriate) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
