### PR TITLE
Support build on vpn network with proxy

### DIFF
--- a/executable.Dockerfile
+++ b/executable.Dockerfile
@@ -171,6 +171,9 @@ RUN ./openssl_build.sh
 COPY ./scripts/python310_build.sh .
 RUN ./python310_build.sh
 
+ARG PROXY=false
+ENV PROXY=${PROXY}
+
 # gProfiler part
 
 WORKDIR /app
@@ -194,12 +197,20 @@ RUN set -e; \
     fi
 RUN set -e; \
     if [ "$(uname -m)" = "aarch64" ]; then \
-        python3 -m pip install --trusted-host files.pythonhosted.org --trusted-host pypi.org --no-cache-dir 'wheel==0.37.0' 'scons==4.2.0'; \
+        if [ "$PROXY" = "true" ]; then \
+            python3 -m pip install --trusted-host files.pythonhosted.org --trusted-host pypi.org --no-cache-dir 'wheel==0.37.0' 'scons==4.2.0'; \
+        else \
+            python3 -m pip install --no-cache-dir 'wheel==0.37.0' 'scons==4.2.0'; \
+        fi \
     fi
 
 # we want the latest pip
 # hadolint ignore=DL3013
-RUN python3 -m pip install --trusted-host files.pythonhosted.org --trusted-host pypi.org --no-cache-dir --upgrade pip
+RUN if [ "$PROXY" = "true" ]; then \
+        python3 -m pip install --trusted-host files.pythonhosted.org --trusted-host pypi.org --no-cache-dir --upgrade pip; \
+    else \
+        python3 -m pip install --no-cache-dir --upgrade pip; \
+    fi
 
 FROM ${NODE_PACKAGE_BUILDER_GLIBC} as node-package-builder-glibc
 USER 0
@@ -224,10 +235,18 @@ COPY requirements.txt requirements.txt
 COPY granulate-utils/setup.py granulate-utils/requirements.txt granulate-utils/README.md granulate-utils/
 COPY granulate-utils/granulate_utils granulate-utils/granulate_utils
 COPY granulate-utils/glogger granulate-utils/glogger
-RUN python3 -m pip install --trusted-host files.pythonhosted.org --trusted-host pypi.org --no-cache-dir -r requirements.txt
+RUN if [ "$PROXY" = "true" ]; then \
+        python3 -m pip install --trusted-host files.pythonhosted.org --trusted-host pypi.org --no-cache-dir -r requirements.txt; \
+    else \
+        python3 -m pip install --no-cache-dir -r requirements.txt; \
+    fi
 
 COPY exe-requirements.txt exe-requirements.txt
-RUN python3 -m pip install --trusted-host files.pythonhosted.org --trusted-host pypi.org --no-cache-dir -r exe-requirements.txt
+RUN if [ "$PROXY" = "true" ]; then \
+        python3 -m pip install --trusted-host files.pythonhosted.org --trusted-host pypi.org --no-cache-dir -r exe-requirements.txt; \
+    else \
+        python3 -m pip install --no-cache-dir -r exe-requirements.txt; \
+    fi
 
 # copy PyPerf, licenses and notice file.
 RUN mkdir -p gprofiler/resources/ruby && \
@@ -287,7 +306,11 @@ RUN if [ "$(uname -m)" = "aarch64" ]; then \
         git apply ../staticx_patch.diff && \
         ln -s libnss_files.so.2 /lib64/libnss_files.so && \
         ln -s libnss_dns.so.2 /lib64/libnss_dns.so && \
-        python3 -m pip install --trusted-host files.pythonhosted.org --trusted-host pypi.org --no-cache-dir . ; \
+        if [ "$PROXY" = "true" ]; then \
+            python3 -m pip install --trusted-host files.pythonhosted.org --trusted-host pypi.org --no-cache-dir . ; \
+        else \
+            python3 -m pip install --no-cache-dir . ; \
+        fi \
     fi
 
 RUN yum install -y patchelf upx && yum clean all

--- a/executable.Dockerfile
+++ b/executable.Dockerfile
@@ -174,6 +174,11 @@ RUN ./python310_build.sh
 ARG PROXY=""
 ENV PIP_TRUST_HOSTS=${PROXY}
 
+RUN set -e; \
+    if [ "$PIP_TRUST_HOSTS" != "" ]; then \
+        python3 -m pip config set global.trusted-host "$(python3 -m pip config get global.trusted-host) $PIP_TRUST_HOSTS"; \
+    fi
+
 # gProfiler part
 
 WORKDIR /app
@@ -197,12 +202,12 @@ RUN set -e; \
     fi
 RUN set -e; \
     if [ "$(uname -m)" = "aarch64" ]; then \
-        python3 -m pip install $PIP_TRUST_HOSTS --no-cache-dir 'wheel==0.37.0' 'scons==4.2.0'; \
+        python3 -m pip install --no-cache-dir 'wheel==0.37.0' 'scons==4.2.0'; \
     fi
 
 # we want the latest pip
 # hadolint ignore=DL3013
-RUN python3 -m pip install $PIP_TRUST_HOSTS --no-cache-dir --upgrade pip
+RUN python3 -m pip install --no-cache-dir --upgrade pip
 
 FROM ${NODE_PACKAGE_BUILDER_GLIBC} as node-package-builder-glibc
 USER 0
@@ -227,10 +232,10 @@ COPY requirements.txt requirements.txt
 COPY granulate-utils/setup.py granulate-utils/requirements.txt granulate-utils/README.md granulate-utils/
 COPY granulate-utils/granulate_utils granulate-utils/granulate_utils
 COPY granulate-utils/glogger granulate-utils/glogger
-RUN python3 -m pip install $PIP_TRUST_HOSTS --no-cache-dir -r requirements.txt
+RUN python3 -m pip install --no-cache-dir -r requirements.txt
 
 COPY exe-requirements.txt exe-requirements.txt
-RUN python3 -m pip install $PIP_TRUST_HOSTS --no-cache-dir -r exe-requirements.txt
+RUN python3 -m pip install --no-cache-dir -r exe-requirements.txt
 
 # copy PyPerf, licenses and notice file.
 RUN mkdir -p gprofiler/resources/ruby && \
@@ -290,7 +295,7 @@ RUN if [ "$(uname -m)" = "aarch64" ]; then \
         git apply ../staticx_patch.diff && \
         ln -s libnss_files.so.2 /lib64/libnss_files.so && \
         ln -s libnss_dns.so.2 /lib64/libnss_dns.so && \
-        python3 -m pip install $PIP_TRUST_HOSTS --no-cache-dir . ; \
+        python3 -m pip install --no-cache-dir . ; \
     fi
 
 RUN yum install -y patchelf upx && yum clean all

--- a/executable.Dockerfile
+++ b/executable.Dockerfile
@@ -194,12 +194,12 @@ RUN set -e; \
     fi
 RUN set -e; \
     if [ "$(uname -m)" = "aarch64" ]; then \
-        python3 -m pip install --no-cache-dir 'wheel==0.37.0' 'scons==4.2.0'; \
+        python3 -m pip install --trusted-host files.pythonhosted.org --trusted-host pypi.org --no-cache-dir 'wheel==0.37.0' 'scons==4.2.0'; \
     fi
 
 # we want the latest pip
 # hadolint ignore=DL3013
-RUN python3 -m pip install --no-cache-dir --upgrade pip
+RUN python3 -m pip install --trusted-host files.pythonhosted.org --trusted-host pypi.org --no-cache-dir --upgrade pip
 
 FROM ${NODE_PACKAGE_BUILDER_GLIBC} as node-package-builder-glibc
 USER 0
@@ -224,10 +224,10 @@ COPY requirements.txt requirements.txt
 COPY granulate-utils/setup.py granulate-utils/requirements.txt granulate-utils/README.md granulate-utils/
 COPY granulate-utils/granulate_utils granulate-utils/granulate_utils
 COPY granulate-utils/glogger granulate-utils/glogger
-RUN python3 -m pip install --no-cache-dir -r requirements.txt
+RUN python3 -m pip install --trusted-host files.pythonhosted.org --trusted-host pypi.org --no-cache-dir -r requirements.txt
 
 COPY exe-requirements.txt exe-requirements.txt
-RUN python3 -m pip install --no-cache-dir -r exe-requirements.txt
+RUN python3 -m pip install --trusted-host files.pythonhosted.org --trusted-host pypi.org --no-cache-dir -r exe-requirements.txt
 
 # copy PyPerf, licenses and notice file.
 RUN mkdir -p gprofiler/resources/ruby && \
@@ -287,7 +287,7 @@ RUN if [ "$(uname -m)" = "aarch64" ]; then \
         git apply ../staticx_patch.diff && \
         ln -s libnss_files.so.2 /lib64/libnss_files.so && \
         ln -s libnss_dns.so.2 /lib64/libnss_dns.so && \
-        python3 -m pip install --no-cache-dir . ; \
+        python3 -m pip install --trusted-host files.pythonhosted.org --trusted-host pypi.org --no-cache-dir . ; \
     fi
 
 RUN yum install -y patchelf upx && yum clean all

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 importlib-resources==5.1.0
 psutil==5.9.8
-requests==2.32.0
+requests==2.31.0
 ConfigArgParse==1.3
 distro==1.7.0
 setuptools==65.5.1  # For pkg_resources

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 importlib-resources==5.1.0
 psutil==5.9.8
-requests==2.31.0
+requests==2.32.0
 ConfigArgParse==1.3
 distro==1.7.0
 setuptools==65.5.1  # For pkg_resources

--- a/scripts/build_x86_64_executable.sh
+++ b/scripts/build_x86_64_executable.sh
@@ -24,7 +24,7 @@ else
 fi
 
 if [[ ("$#" -gt 0 && "$1" == "--proxy") || ("$#" -gt 1 && "$2" == "--proxy") ]]; then
-    with_proxy="--trusted-host files.pythonhosted.org --trusted-host pypi.org"
+    with_proxy="files.pythonhosted.org pypi.org"
     shift
 else
     with_proxy=""

--- a/scripts/build_x86_64_executable.sh
+++ b/scripts/build_x86_64_executable.sh
@@ -16,11 +16,18 @@
 #
 set -euo pipefail
 
-if [ "$#" -gt 0 ] && [ "$1" == "--fast" ]; then
+if [[ ("$#" -gt 0 && "$1" == "--fast") || ("$#" -gt 1 && "$2" == "--fast") ]]; then
     with_staticx=false
     shift
 else
     with_staticx=true
+fi
+
+if [[ ("$#" -gt 0 && "$1" == "--proxy") || ("$#" -gt 1 && "$2" == "--proxy") ]]; then
+    with_proxy=true
+    shift
+else
+    with_proxy=false
 fi
 
 # pyspy & rbspy, using the same builder for both pyspy and rbspy since they share build dependencies - rust:1.59-alpine3.15
@@ -65,4 +72,5 @@ docker buildx build -f executable.Dockerfile --output type=local,dest=build/x86_
     --build-arg NODE_PACKAGE_BUILDER_MUSL=$AP_BUILDER_ALPINE \
     --build-arg NODE_PACKAGE_BUILDER_GLIBC=$NODE_PACKAGE_BUILDER_GLIBC \
     --build-arg STATICX=$with_staticx \
+    --build-arg PROXY=$with_proxy \
     . "$@"

--- a/scripts/build_x86_64_executable.sh
+++ b/scripts/build_x86_64_executable.sh
@@ -24,10 +24,10 @@ else
 fi
 
 if [[ ("$#" -gt 0 && "$1" == "--proxy") || ("$#" -gt 1 && "$2" == "--proxy") ]]; then
-    with_proxy=true
+    with_proxy="--trusted-host files.pythonhosted.org --trusted-host pypi.org"
     shift
 else
-    with_proxy=false
+    with_proxy=""
 fi
 
 # pyspy & rbspy, using the same builder for both pyspy and rbspy since they share build dependencies - rust:1.59-alpine3.15
@@ -72,5 +72,5 @@ docker buildx build -f executable.Dockerfile --output type=local,dest=build/x86_
     --build-arg NODE_PACKAGE_BUILDER_MUSL=$AP_BUILDER_ALPINE \
     --build-arg NODE_PACKAGE_BUILDER_GLIBC=$NODE_PACKAGE_BUILDER_GLIBC \
     --build-arg STATICX=$with_staticx \
-    --build-arg PROXY=$with_proxy \
+    --build-arg PROXY="$with_proxy" \
     . "$@"

--- a/scripts/prepare_machine-unknown-linux-musl.sh
+++ b/scripts/prepare_machine-unknown-linux-musl.sh
@@ -36,7 +36,7 @@ mkdir builds && cd builds
 
 ZLIB_VERSION="1.3.1"
 ZLIB_FILE="zlib-$ZLIB_VERSION.tar.xz"
-wget "https://zlib.net/$ZLIB_FILE"
+curl "https://zlib.net/$ZLIB_FILE" > $ZLIB_FILE
 tar -xf "$ZLIB_FILE"
 cd "zlib-$ZLIB_VERSION"
 # note the use of --prefix here. it matches the directory https://github.com/benfred/remoteprocess/blob/master/build.rs expects to find libs for musl.


### PR DESCRIPTION
This is to provide the workaround for pip install failure due to proxy. 
The error signature related to the proxy issue is 
_Could not fetch URL https://pypi.org/simple/pip/: There was a problem confirming the ssl certificate: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /simple/pip/ (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1007)'))) - skipping_

To workaround the issue, we need to ignore SSL errors by setting [pypi.org](https://pypi.org/) and [files.pythonhosted.org](https://files.pythonhosted.org/) as well as the older [pypi.python.org](https://pypi.python.org/) as trusted hosts.

I explored the alternative workaround using the pip config but it didn't work.

## Related Issue
<!--- If there's an issue related, please link it here -->
<!--- If suggesting a new feature or a medium/big change, please discuss it in an issue first. -->
<!--- For small changes, it's okay to open a PR immediately. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? What does it improve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your changes are tested by the CI, you can just write that.-->

## Screenshots
<!--- (if appropriate) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
