### PR TITLE
Update CodeQL workflow triggers

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,9 +14,11 @@ name: "CodeQL Advanced"
 permissions: 
   security-events: write
 
-on: 
+on:
+  workflow_dispatch:
   pull_request:
   push:
+    branches: [ "master" ]
     tags:
       - '**'
 


### PR DESCRIPTION
## Description
Changes the CodeQL workflow triggers to enable manual running and limit push triggers only to master branch.

## Motivation and Context
This is working for gProfiler Performance Studio repo, want to use it here too.
