### PR TITLE
Support java profiling without root privilege in a container

### DIFF
--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -54,6 +54,7 @@ if is_linux():
         get_process_nspid,
         resolve_proc_root_links,
         run_in_ns_wrapper,
+        is_root,
     )
     from granulate_utils.linux.oom import get_oom_entry
     from granulate_utils.linux.process import (
@@ -527,7 +528,7 @@ class AsyncProfiledProcess:
         #   ancestor is still alive.
         # there is a hidden assumption here that neither the ancestor nor the process will change their mount
         # namespace. I think it's okay to assume that.
-        self._process_root = get_proc_root_path(process)
+        self._process_root = get_proc_root_path(process, from_ancestor = True if is_root() else False)
         self._cmdline = process.cmdline()
         self._cwd = process.cwd()
         self._nspid = get_process_nspid(self.process.pid)
@@ -583,6 +584,11 @@ class AsyncProfiledProcess:
             if not full_dir.parent.exists():
                 continue  # we do not create the parent.
 
+            # Bypass the root check in case of rootless collection
+            if not is_root():
+                logger.debug("_find_rw_exec_dir", full_dir=full_dir)
+                return str(full_dir)
+
             if not is_owned_by_root(full_dir.parent):
                 continue  # the parent needs to be owned by root
 
@@ -606,9 +612,11 @@ class AsyncProfiledProcess:
         # for sanity & simplicity, mkdir_owned_root() does not support creating parent directories, as this allows
         # the caller to absentmindedly ignore the check of the parents ownership.
         # hence we create the structure here part by part.
-        assert is_owned_by_root(
-            Path(self._ap_dir_base)
-        ), f"expected {self._ap_dir_base} to be owned by root at this point"
+        # Bypass the root check in case of rootless collection
+        if is_root():
+            assert is_owned_by_root(
+                Path(self._ap_dir_base)
+                ), f"expected {self._ap_dir_base} to be owned by root at this point"
         mkdir_owned_root(self._ap_dir_versioned)
         mkdir_owned_root(self._ap_dir_host)
         os.makedirs(self._storage_dir_host, 0o755, exist_ok=True)

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -528,7 +528,7 @@ class AsyncProfiledProcess:
         #   ancestor is still alive.
         # there is a hidden assumption here that neither the ancestor nor the process will change their mount
         # namespace. I think it's okay to assume that.
-        self._process_root = get_proc_root_path(process, from_ancestor = True if is_root() else False)
+        self._process_root = get_proc_root_path(process, from_ancestor=True if is_root() else False)
         self._cmdline = process.cmdline()
         self._cwd = process.cwd()
         self._nspid = get_process_nspid(self.process.pid)
@@ -616,7 +616,7 @@ class AsyncProfiledProcess:
         if is_root():
             assert is_owned_by_root(
                 Path(self._ap_dir_base)
-                ), f"expected {self._ap_dir_base} to be owned by root at this point"
+            ), f"expected {self._ap_dir_base} to be owned by root at this point"
         mkdir_owned_root(self._ap_dir_versioned)
         mkdir_owned_root(self._ap_dir_host)
         os.makedirs(self._storage_dir_host, 0o755, exist_ok=True)

--- a/gprofiler/utils/fs.py
+++ b/gprofiler/utils/fs.py
@@ -133,5 +133,5 @@ def mkdir_owned_root(path: Union[str, Path], mode: int = 0o755) -> None:
         pass
 
     if is_root() and not is_owned_by_root(path):
-       # lost race with someone else?
+        # lost race with someone else?
         raise Exception(f"Failed to create directory {str(path)} as owned by root")

--- a/gprofiler/utils/fs.py
+++ b/gprofiler/utils/fs.py
@@ -112,16 +112,16 @@ def mkdir_owned_root(path: Union[str, Path], mode: int = 0o755) -> None:
     If the directory exists and is not owned by root, it is removed and recreated. If after recreation
     it is still not owned by root, the function raises.
     """
-    assert is_root()  # this function behaves as we expect only when run as root
 
     path = path if isinstance(path, Path) else Path(path)
     # parent is expected to be root - otherwise, after we create the root-owned directory, it can be removed
     # as re-created as non-root by a regular user.
-    if not is_owned_by_root(path.parent):
+    if is_root() and not is_owned_by_root(path.parent):
         raise Exception(f"expected {path.parent} to be owned by root!")
 
     if path.exists():
-        if is_owned_by_root(path):
+        return
+        if is_root() and is_owned_by_root(path):
             return
 
         shutil.rmtree(path)
@@ -132,6 +132,6 @@ def mkdir_owned_root(path: Union[str, Path], mode: int = 0o755) -> None:
         # likely racing with another thread of gprofiler. as long as the directory is root after all, we're good.
         pass
 
-    if not is_owned_by_root(path):
-        # lost race with someone else?
+    if is_root() and not is_owned_by_root(path):
+       # lost race with someone else?
         raise Exception(f"Failed to create directory {str(path)} as owned by root")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This patch resolves #957. It removes the root ownership checks when the sudoless profiling is requested.

## Related Issue
<!--- If there's an issue related, please link it here -->
<!--- If suggesting a new feature or a medium/big change, please discuss it in an issue first. -->
<!--- For small changes, it's okay to open a PR immediately. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? What does it improve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your changes are tested by the CI, you can just write that.-->

## Screenshots
<!--- (if appropriate) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
