### PR TITLE
Fix popen leak

### DIFF
--- a/gprofiler/utils/__init__.py
+++ b/gprofiler/utils/__init__.py
@@ -264,6 +264,10 @@ def run_process(
             reraise_exc = e
         retcode = process.poll()
         assert retcode is not None  # only None if child has not terminated
+        try:
+            _processes.remove(process)
+        except ValueError:
+            pass  # already removed
 
     result: CompletedProcess[bytes] = CompletedProcess(process.args, retcode, stdout, stderr)
 


### PR DESCRIPTION
This is the first attempt to clean up the popen object being still referenced after the associated subprocess gets terminated.

Based on code review, here are the findings:
1. With python 3.2 or later, subprocess.Popen supports the context manager protocol for **with** statement, which means __exit__ method is implemented and executed when t the with block ends. Popen.__exit__ calls proc.wait() by default.
2. At the end of the with block, it looks we ensures the process is terminated by checking the retcode from poll(). https://github.com/intel/gprofiler/blob/63ef4354e2ed12b176983a179218eb4aabf42b8d/gprofiler/utils/__init__.py#L266

If the assertion does NOT happen, the subprocess is terminated. At this time, I think we should remove the popen object in the global list so that the pipes and file descriptors are cleaned by GC.

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- If there's an issue related, please link it here -->
<!--- If suggesting a new feature or a medium/big change, please discuss it in an issue first. -->
<!--- For small changes, it's okay to open a PR immediately. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? What does it improve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your changes are tested by the CI, you can just write that.-->

## Screenshots
<!--- (if appropriate) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
