### PR TITLE
Fix popen leak and handle perf script crash

### DIFF
--- a/gprofiler/profilers/php.py
+++ b/gprofiler/profilers/php.py
@@ -30,7 +30,14 @@ from gprofiler.log import get_logger_adapter
 from gprofiler.profiler_state import ProfilerState
 from gprofiler.profilers.profiler_base import ProfilerBase
 from gprofiler.profilers.registry import ProfilerArgument, register_profiler
-from gprofiler.utils import random_prefix, reap_process, resource_path, start_process, wait_event
+from gprofiler.utils import (
+    random_prefix,
+    reap_process,
+    resource_path,
+    start_process,
+    wait_event,
+    cleanup_process_reference,
+)
 
 logger = get_logger_adapter(__name__)
 # Currently tracing only php-fpm, TODO: support mod_php in apache.
@@ -104,19 +111,25 @@ class PHPSpyProfiler(ProfilerBase):
         phpspy_dir = os.path.dirname(phpspy_path)
         env = os.environ.copy()
         env["PATH"] = f"{env.get('PATH')}:{phpspy_dir}"
-        process = start_process(cmd, env=env)
+        phpspy_proc = start_process(cmd, env=env)
         # Executing phpspy, expecting the output file to be created, phpspy creates it at bootstrap after argument
         # parsing.
         # If an error occurs after this stage it's probably a spied _process specific and not phpspy general error.
         try:
             wait_event(self.poll_timeout, self._profiler_state.stop_event, lambda: os.path.exists(self._output_path))
         except TimeoutError:
-            process.kill()
-            assert process.stdout is not None and process.stderr is not None
-            logger.error(f"phpspy failed to start. stdout {process.stdout.read()!r} stderr {process.stderr.read()!r}")
+            phpspy_proc.kill()
+            # Clean up the global reference
+            cleanup_process_reference(process=phpspy_proc)
+            assert phpspy_proc.stdout is not None and phpspy_proc.stderr is not None
+            logger.error(
+                "phpspy failed to start. stdout %r stderr %r",
+                phpspy_proc.stdout.read(),
+                phpspy_proc.stderr.read(),
+            )
             raise
         else:
-            self._process = process
+            self._process = phpspy_proc
 
         # Set the stderr fd as non-blocking so the read operation on it won't block if no data is available.
         assert self._process.stderr is not None
@@ -130,9 +143,33 @@ class PHPSpyProfiler(ProfilerBase):
         stderr = self._process.stderr.read1().decode()  # type: ignore
         logger.debug("phpspy stderr", stderr=self._filter_phpspy_stderr(stderr))
 
+    def _check_process_health(self) -> bool:
+        """Check if the process is still alive and clean up if not"""
+        if self._process is None:
+            return False
+
+        if self._process.poll() is not None:
+            # Process has terminated
+            logger.warning("phpspy process has terminated unexpectedly")
+            cleanup_process_reference(process=self._process)
+            self._process = None
+            return False
+
+        return True
+
     def _dump(self) -> Path:
-        assert self._process is not None, "profiling not started!"
-        self._process.send_signal(self.dump_signal)
+        if not self._check_process_health():
+            raise Exception("phpspy process is not running")
+
+        try:
+            self._process.send_signal(self.dump_signal)
+        except ProcessLookupError:
+            # Process died between health check and signal send
+            if self._process is not None:
+                cleanup_process_reference(process=self._process)
+                self._process = None
+            raise Exception("phpspy process crashed before dump signal")
+
         # important to not grab the transient data file
         while True:
             output_files = glob.glob(f"{str(self._output_path)}.*")
@@ -218,12 +255,26 @@ class PHPSpyProfiler(ProfilerBase):
         return profiles
 
     def snapshot(self) -> ProcessToProfileData:
+        # Add health check at the beginning
+        if not self._check_process_health():
+            raise Exception("phpspy process has crashed or terminated")
+
         if self._profiler_state.stop_event.wait(self._duration):
             raise StopEventSetException()
-        stderr = self._process.stderr.read1().decode()  # type: ignore
-        logger.debug("phpspy stderr", stderr=self._filter_phpspy_stderr(stderr))
 
-        phpspy_output_path = self._dump()
+        try:
+            stderr = self._process.stderr.read1().decode()  # type: ignore
+            logger.debug("phpspy stderr", stderr=self._filter_phpspy_stderr(stderr))
+            phpspy_output_path = self._dump()
+        except (BrokenPipeError, ProcessLookupError, OSError) as e:
+            # Process crashed during operation
+            logger.error(f"phpspy process crashed during snapshot: {e}")
+            if self._process is not None:
+                # Clean up the global reference
+                cleanup_process_reference(self._process)
+                self._process = None
+            raise Exception("phpspy process crashed during snapshot") from e
+
         phpspy_output_text = phpspy_output_path.read_text()
         phpspy_output_path.unlink()
         return self._parse_phpspy_output(phpspy_output_text, self._profiler_state)
@@ -232,6 +283,8 @@ class PHPSpyProfiler(ProfilerBase):
         if self._process is not None:
             self._process.terminate()
             exit_code, stdout, stderr = reap_process(self._process)
+            # Clean up global reference
+            cleanup_process_reference(process=self._process)
             self._process = None
             logger.info(
                 "Finished profiling PHP processes with phpspy",

--- a/gprofiler/utils/__init__.py
+++ b/gprofiler/utils/__init__.py
@@ -264,6 +264,10 @@ def run_process(
             reraise_exc = e
         retcode = process.poll()
         assert retcode is not None  # only None if child has not terminated
+        try:
+            _processes.remove(process)
+        except ValueError:
+            pass  # already removed
 
     result: CompletedProcess[bytes] = CompletedProcess(process.args, retcode, stdout, stderr)
 
@@ -522,6 +526,14 @@ def merge_dicts(source: Dict[str, Any], dest: Dict[str, Any]) -> Dict[str, Any]:
 
 def is_profiler_disabled(profile_mode: str) -> bool:
     return profile_mode in ("none", "disabled")
+
+
+def cleanup_process_reference(process: Popen) -> None:
+    """Remove process from global _processes list"""
+    try:
+        _processes.remove(process)
+    except ValueError:
+        pass  # Already removed
 
 
 def _exit_handler() -> None:

--- a/gprofiler/utils/perf_process.py
+++ b/gprofiler/utils/perf_process.py
@@ -18,7 +18,10 @@ from gprofiler.utils import (
     start_process,
     wait_event,
     wait_for_file_by_prefix,
+    cleanup_process_reference
 )
+
+from gprofiler.exceptions import CalledProcessError
 
 logger = get_logger_adapter(__name__)
 
@@ -102,6 +105,7 @@ class PerfProcess:
             self.start_time = time.monotonic()
         except TimeoutError:
             process.kill()
+            cleanup_process_reference(process=process)
             assert process.stdout is not None and process.stderr is not None
             logger.critical(
                 f"{self._log_name} failed to start", stdout=process.stdout.read(), stderr=process.stderr.read()
@@ -117,6 +121,7 @@ class PerfProcess:
         if self._process is not None:
             self._process.terminate()  # okay to call even if process is already dead
             exit_code, stdout, stderr = reap_process(self._process)
+            cleanup_process_reference(process=self._process)
             self._process = None
             logger.info(f"Stopped {self._log_name}", exit_code=exit_code, stderr=stderr, stdout=stdout)
 
@@ -165,6 +170,9 @@ class PerfProcess:
         try:
             perf_data = wait_for_file_by_prefix(f"{self._output_path}.", self._DUMP_TIMEOUT_S, self._stop_event)
         except Exception:
+            # Check if process died first
+            process_died = self._process is not None and self._process.poll() is not None
+
             assert self._process is not None and self._process.stdout is not None and self._process.stderr is not None
             logger.critical(
                 f"{self._log_name} failed to dump output",
@@ -172,13 +180,18 @@ class PerfProcess:
                 perf_stderr=self._process.stderr.read(),
                 perf_running=self.is_running(),
             )
+
+            # Clean up after logging
+            if process_died:
+                cleanup_process_reference(process=self._process)
+                self._process = None
             raise
         finally:
             # always read its stderr
             # using read1() which performs just a single read() call and doesn't read until EOF
             # (unlike Popen.communicate())
-            assert self._process is not None and self._process.stderr is not None
-            logger.debug(f"{self._log_name} run output", perf_stderr=self._process.stderr.read1())  # type: ignore
+            if self._process is not None and self._process.stderr is not None:
+                logger.debug(f"{self._log_name} run output", perf_stderr=self._process.stderr.read1())  # type: ignore
 
         try:
             inject_data = Path(f"{str(perf_data)}.inject")
@@ -189,10 +202,18 @@ class PerfProcess:
                 perf_data.unlink()
                 perf_data = inject_data
 
-            perf_script_proc = run_process(
-                [perf_path(), "script", "-F", "+pid", "-i", str(perf_data)],
-                suppress_log=True,
-            )
+            perf_script_cmd = [perf_path(), "script", "-F", "+pid", "-i", str(perf_data)]
+            try:
+                perf_script_proc = run_process(
+                    perf_script_cmd,
+                    suppress_log=True,
+                )
+            except CalledProcessError as e:
+                logger.critical(
+                    f"{self._log_name} failed to run perf script: {str(e)}",
+                    command=" ".join(perf_script_cmd),
+                )
+                return ""
             return perf_script_proc.stdout.decode("utf8")
         finally:
             perf_data.unlink()


### PR DESCRIPTION
The patch is revised to take care of cleaning up the popen object being still referenced after the associated subprocess gets terminated.

Based on code review, 3 issues are identified:
1. In run_process function, If the assertion does NOT happen, the subprocess is terminated. At this time, I think we should remove the popen object in the global list so that the pipes and file descriptors are cleaned by GC.
- a. With python 3.2 or later, subprocess.Popen supports the context manager protocol for **with** statement, which means __exit__ method is implemented and executed when t the with block ends. Popen.__exit__ calls proc.wait() by default.
- b. At the end of the with block, it looks we ensures the process is terminated by checking the retcode from poll(). https://github.com/intel/gprofiler/blob/63ef4354e2ed12b176983a179218eb4aabf42b8d/gprofiler/utils/__init__.py#L266
2. Some profilers (php, pyperf, perf) call the start_process function directly. So, the above solution for run_process is not helpful. So, we handle the clean up separately here
3. When "perf script" is crashed, we need to add the handling of exception which should fixes #992 


## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- If there's an issue related, please link it here -->
<!--- If suggesting a new feature or a medium/big change, please discuss it in an issue first. -->
<!--- For small changes, it's okay to open a PR immediately. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? What does it improve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your changes are tested by the CI, you can just write that.-->

## Screenshots
<!--- (if appropriate) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
