### PR TITLE
Address the slow growth of memory utilization with perf

### DIFF
--- a/container.Dockerfile
+++ b/container.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine as gprofiler
+FROM alpine AS gprofiler
 
 ARG ARCH
 ARG EXE_PATH=build/${ARCH}/gprofiler

--- a/gprofiler/utils/__init__.py
+++ b/gprofiler/utils/__init__.py
@@ -136,6 +136,7 @@ def start_process(
         **kwargs,
     )
 
+    _processes.append(process)
     return process
 
 
@@ -190,11 +191,28 @@ def reap_process(process: Popen) -> Tuple[int, bytes, bytes]:
     (see https://docs.python.org/3/library/subprocess.html#subprocess.Popen.wait, and see
     ticket https://github.com/intel/gprofiler/issues/744).
     """
-    stdout, stderr = process.communicate()
-    returncode = process.poll()
-    assert returncode is not None  # only None if child has not terminated
-    return returncode, stdout, stderr
+    # If process is already terminated, don't try to communicate
+    if process.poll() is not None:
+        # Process already exited, just collect any remaining output
+        try:
+            stdout = process.stdout.read() if process.stdout and not process.stdout.closed else b''
+            stderr = process.stderr.read() if process.stderr and not process.stderr.closed else b''
+        except Exception:
+            stdout, stderr = b'', b''
+        return process.returncode, stdout, stderr
 
+    # Process still running, try normal communicate
+    try:
+        stdout, stderr = process.communicate()
+        return process.returncode, stdout, stderr
+    except ValueError as e:
+        if "flush of closed file" in str(e):
+            # Handle the race condition gracefully
+            returncode = process.wait()
+            stdout, stderr = b'', b''
+            return returncode, stdout, stderr
+        else:
+            raise
 
 def _kill_and_reap_process(process: Popen, kill_signal: signal.Signals) -> Tuple[int, bytes, bytes]:
     process.send_signal(kill_signal)


### PR DESCRIPTION
It seems the perf has known issue regarding memory utilization when perf runs continuously. As it's observed on idle system where there are not many processes running and output file sizes are not huge, it looks the perf has to be restarted if its internal memory usage is beyond a threshold. 
The solution I implement here is to restart the perf collection when the memory utilization growth is more than 100MB (which can be changed depending on use cases, we can also make it as command line argument), compared the first memory RSS size. 

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- If there's an issue related, please link it here -->
<!--- If suggesting a new feature or a medium/big change, please discuss it in an issue first. -->
<!--- For small changes, it's okay to open a PR immediately. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? What does it improve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your changes are tested by the CI, you can just write that.-->

## Screenshots
<!--- (if appropriate) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
